### PR TITLE
Require latest Axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "NODE_ENV=test jest"
   },
   "dependencies": {
-    "axios": "^0.21.1"
+    "axios": "^0.27.2"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "NODE_ENV=test jest"
   },
   "dependencies": {
-    "axios": "^0.27.2"
+    "axios": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "NODE_ENV=test jest"
   },
   "dependencies": {
-    "axios": "^0.18.0"
+    "axios": "^0.21.1"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",


### PR DESCRIPTION
**Overview**
The `axios` NPM package before 0.21.1 contains a Server-Side Request Forgery (SSRF) vulnerability where an attacker is able to bypass a proxy by providing a URL that responds with a redirect to a restricted host or IP address.

**Remediation**
Upgrade to 0.21.1 or later.

Source: https://www.npmjs.com/advisories/1594